### PR TITLE
Lista de ficheiros a não sincronizar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+# Windows
+
+# Windows image file caches
+Thumbs.db
+
+# Folder config file
+Desktop.ini
+
+
+# Mac
+.DS_Store


### PR DESCRIPTION
o `.gitignore` lista os ficheiros que o git deve ignorar e nunca tentar sincronizar.
Podes incluir aqui mais coisas, conforme precisares.
https://help.github.com/articles/ignoring-files/